### PR TITLE
Change camera to use V4L2 instead of OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 
 project(livestream)
 
-find_package(OpenCV REQUIRED )
-
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 set(CMAKE_CXX_FLAG "-g -Wall -std=c++14")

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -20,6 +20,7 @@
 
 typedef struct {
     size_t length;
+    size_t dataLength;
     void* data; // you must manually free the allocated data array
 } Frame_t;
 

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -1,16 +1,44 @@
 #pragma once
 
 #include <iostream>
+#include <cstring>
+#include <string>
 
-#include <opencv2/opencv.hpp>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <linux/videodev2.h>
+#include <libv4l2.h>
+
+typedef struct {
+    size_t length;
+    void* data; // you must manually free the allocated data array
+} Frame_t;
 
 class Camera {
 public:
     Camera();
     ~Camera();
 
-    cv::Mat getFrame();
+    Frame_t getFrame();
 
+    static const std::string VIDEO_DEVICE_DRIVER_PATH;
+    static const size_t FRAME_WIDTH;
+    static const size_t FRAME_HEIGHT;
 private:
-    cv::VideoCapture cap;
+
+    void setFormat(struct v4l2_format &format);
+    static int xioctl(int fileDescriptor, int request, void *arguments);
+
+    int cameraFileDescriptor;
+
+    //cv::VideoCapture cap;
 };

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -25,8 +25,11 @@ typedef struct {
 
 class Camera {
 public:
-    Camera();
+    Camera(size_t numberOfBuffers);
     ~Camera();
+
+    void startStreaming();
+    void stopStreaming();
 
     Frame_t getFrame();
 
@@ -36,9 +39,15 @@ public:
 private:
 
     void setFormat(struct v4l2_format &format);
+    void mapInMemoryBuffersToCameraBuffers(size_t numberOfBuffers);
+    void enqueuBuffers(size_t numberOfBuffers);
+
     static int xioctl(int fileDescriptor, int request, void *arguments);
 
     int cameraFileDescriptor;
+    size_t numberOfBuffers;
+
+    Frame_t* frames;
 
     //cv::VideoCapture cap;
 };

--- a/scripts/addHeaderToMpegData.sh
+++ b/scripts/addHeaderToMpegData.sh
@@ -1,0 +1,1 @@
+ffmpeg -f h264 -i $1 -vcodec copy $2

--- a/src/camera/CMakeLists.txt
+++ b/src/camera/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(camera Camera.cpp)
 
-target_link_libraries(camera ${OpenCV_LIBS})
+target_link_libraries(camera v4l2)

--- a/src/camera/Camera.cpp
+++ b/src/camera/Camera.cpp
@@ -5,7 +5,9 @@ const size_t Camera::FRAME_WIDTH = 1920;
 const size_t Camera::FRAME_HEIGHT = 1080;
 
 
-Camera::Camera() {
+Camera::Camera(size_t numberOfBuffers) :
+        numberOfBuffers(numberOfBuffers),
+        frames(NULL) {
     struct v4l2_format format;
 
     cameraFileDescriptor = v4l2_open(VIDEO_DEVICE_DRIVER_PATH.c_str(), O_RDWR | O_NONBLOCK, 0);
@@ -15,6 +17,17 @@ Camera::Camera() {
     }
 
     setFormat(format);
+    mapInMemoryBuffersToCameraBuffers(numberOfBuffers);
+    enqueuBuffers(numberOfBuffers);
+    startStreaming();
+}
+
+Camera::~Camera() {
+    for (int i = 0; i < numberOfBuffers; ++i) {
+        v4l2_munmap(frames[i].data, frames[i].length);
+    }
+    delete[] frames;
+    v4l2_close(cameraFileDescriptor);
 }
 
 void Camera::setFormat(struct v4l2_format &format) {
@@ -44,96 +57,124 @@ int Camera::xioctl(int fileDescriptor, int request, void *arguments)
         return response;
 }
 
-Frame_t Camera::getFrame() {
+void Camera::mapInMemoryBuffersToCameraBuffers(size_t numberOfBuffers) {
     struct v4l2_requestbuffers requestBuffer;
     struct v4l2_buffer buffer;
-    enum v4l2_buf_type bufferType;
-    Frame_t frame;
-
 
     // request that a buffer be queued
-    requestBuffer.count = 1;
+    requestBuffer.count = numberOfBuffers;
     requestBuffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     requestBuffer.memory = V4L2_MEMORY_MMAP;
 
-    xioctl(cameraFileDescriptor, VIDIOC_REQBUFS, &requestBuffer);
-
-    // get a pointer to the video data buffer on the camera
-    memset(&buffer, 0, sizeof(buffer));
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    buffer.index = 0;
-
-    xioctl(cameraFileDescriptor, VIDIOC_QUERYBUF, &buffer);
-
-    // memory map buffer to frame
-    frame.length = buffer.length;
-    frame.data = v4l2_mmap(
-        NULL,
-        buffer.length,
-        PROT_READ | PROT_WRITE,
-        MAP_SHARED,
-        cameraFileDescriptor,
-        buffer.m.offset
-    );
-
-    if (MAP_FAILED == frame.data) {
-        std::cerr << "FATAL ERROR: mmap() failure occured when trying to load a frame from the webcamera.\n";
-        exit(EXIT_FAILURE);
+    if (xioctl(cameraFileDescriptor, VIDIOC_REQBUFS, &requestBuffer) == -1) {
+        std::cout << "ERROR: could not query camera buffer with size: " << numberOfBuffers << " because: " << strerror(errno) << "\n";
     }
 
 
-    // enque a buffer
-    memset(&buffer, 0, sizeof(buffer));
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    buffer.index = 0;
-    xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
+    assert(frames == NULL);
+    frames = new Frame_t[numberOfBuffers];
 
+    for(int i = 0; i < requestBuffer.count; ++i) {
+        // get a pointer to the video data buffer on the camera
+        memset(&buffer, 0, sizeof(buffer));
+        buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buffer.memory = V4L2_MEMORY_MMAP;
+        buffer.index = i;
 
+        if (xioctl(cameraFileDescriptor, VIDIOC_QUERYBUF, &buffer) == -1) {
+            std::cout << "ERROR: could not map buffer to memory because: " << strerror(errno) << "\n";
+        }
 
+        // memory map buffer to frame
+        frames[i].length = buffer.length;
+        frames[i].data = v4l2_mmap(
+            NULL,
+            buffer.length,
+            PROT_READ | PROT_WRITE,
+            MAP_SHARED,
+            cameraFileDescriptor,
+            buffer.m.offset
+        );
+
+        if (MAP_FAILED == frames[i].data) {
+            std::cerr << "FATAL ERROR: mmap() failure occured when trying to map a buffer to the webcameras memory.\n";
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+void Camera::enqueuBuffers(size_t numberOfBuffers) {
+    struct v4l2_buffer buffer;
+
+    // enque all buffer
+    for (int i = 0; i < numberOfBuffers; ++i) {
+        memset(&buffer, 0, sizeof(buffer));
+
+        buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buffer.memory = V4L2_MEMORY_MMAP;
+        buffer.index = i;
+
+        xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
+    }
+}
+
+void Camera::startStreaming() {
     // start capturing image data
-    bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    enum v4l2_buf_type bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     xioctl(cameraFileDescriptor, VIDIOC_STREAMON, &bufferType);
+}
+
+void Camera::stopStreaming() {
+    enum v4l2_buf_type bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    xioctl(cameraFileDescriptor, VIDIOC_STREAMOFF, &bufferType);
+}
+
+Frame_t Camera::getFrame() {
+    struct v4l2_buffer buffer;
+    Frame_t frame;
 
     fd_set fileDescriptors;
     struct timeval timeout;
 
-    int response = 0;
-    do {
-        FD_ZERO(&fileDescriptors);
-        FD_SET(cameraFileDescriptor, &fileDescriptors);
+    for (int i = 0; i < numberOfBuffers; i++) {
+        int response = 0;
+        do {
+            FD_ZERO(&fileDescriptors);
+            FD_SET(cameraFileDescriptor, &fileDescriptors);
 
-        /* Timeout. */
-        timeout.tv_sec = 10;
-        timeout.tv_usec = 10;
+            /* Timeout. */
+            timeout.tv_sec = 0;
+            timeout.tv_usec = 41;
 
-        response = select(cameraFileDescriptor + 1, &fileDescriptors, NULL, NULL, &timeout);
-    } while ((response == -1 && (errno = EINTR)));
+            response = select(cameraFileDescriptor + 1, &fileDescriptors, NULL, NULL, &timeout);
+        } while ((response == -1 && (errno = EINTR)));
 
-    if (response == -1) {
-        std::cerr << "select\n";
-        //return nullptr;
+        if (response == -1) {
+            std::cerr << "select\n";
+            continue;
+            // return NULL;
+        }
+
+        if (response == 0) {
+            // select timed out
+        }
+
+        // deque the buffer
+        memset(&buffer, 0, sizeof(buffer));
+        buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buffer.memory = V4L2_MEMORY_MMAP;
+        xioctl(cameraFileDescriptor, VIDIOC_DQBUF, &buffer);
+
+        // could process the buffer at this point with a callback in the future.
+        std::cout << "used 1: " << buffer.bytesused << "\n";
+        // frames[buffer.index].length = buffer.bytesused;
+        // re queue the buffer again
+        xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
+
+        std::cout << "used 2: " << buffer.bytesused << "\n";
+
+        return frames[buffer.index];
     }
 
-    // deque the buffer
-    // memset(&buffer, 0, sizeof(buffer));
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    xioctl(cameraFileDescriptor, VIDIOC_DQBUF, &buffer);
-
-    // could process the buffer at this point with a callback in the future.
-
-    // enque the buffer again
-    xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
-
-    // stop streaming
-    bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    xioctl(cameraFileDescriptor, VIDIOC_STREAMOFF, &bufferType);
-
-    return frame;
-}
-
-Camera::~Camera() {
-    close(cameraFileDescriptor);
+    return frames[0];
 }

--- a/src/camera/Camera.cpp
+++ b/src/camera/Camera.cpp
@@ -1,21 +1,132 @@
 #include "Camera.h"
 
+const std::string Camera::VIDEO_DEVICE_DRIVER_PATH = "/dev/video0";
+const size_t Camera::FRAME_WIDTH = 1280;
+const size_t Camera::FRAME_HEIGHT = 1024;
+
 
 Camera::Camera() {
-    cap.open(0);
-    if(!cap.isOpened()) {
-        std::cout << "camera failed" << std::endl;
-        exit(-1);
+    struct v4l2_format format;
+
+    cameraFileDescriptor = v4l2_open(VIDEO_DEVICE_DRIVER_PATH.c_str(), O_RDWR | O_NONBLOCK, 0);
+    if (cameraFileDescriptor < 0) {
+            std::cerr << "FATAL ERROR: Cannot open USB video camera at: " << VIDEO_DEVICE_DRIVER_PATH << std::endl;
+            exit(EXIT_FAILURE);
+    }
+
+    setFormat(format);
+}
+
+void Camera::setFormat(struct v4l2_format &format) {
+    assert(cameraFileDescriptor != 0);
+
+    format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    format.fmt.pix.width = FRAME_WIDTH;
+    format.fmt.pix.height = FRAME_HEIGHT;
+    format.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB24; //V4L2_PIX_FMT_H264; // set pixel capture mode to MPEG-4 AVC mode
+    format.fmt.pix.field = V4L2_FIELD_INTERLACED;
+
+    xioctl(cameraFileDescriptor, VIDIOC_S_FMT, &format);
+    if (format.fmt.pix.pixelformat /*!=*/== V4L2_PIX_FMT_H264) {
+            std::cerr << "FATAL ERROR: Camera did not change to H264 format. This webcam may not support H264 encoding.\n";
+            exit(EXIT_FAILURE);
     }
 }
 
-cv::Mat Camera::getFrame() {
-    cv::Mat frame;
-    cap >> frame;
+int Camera::xioctl(int fileDescriptor, int request, void *arguments)
+{
+        int response;
+
+        do {
+            response = ioctl(fileDescriptor, request, arguments);
+        } while (-1 == response && EINTR == errno);
+
+        return response;
+}
+
+Frame_t Camera::getFrame() {
+    std::cout << "getting new frame\n";
+    struct v4l2_requestbuffers requestBuffer;
+    struct v4l2_buffer buffer;
+    enum v4l2_buf_type bufferType;
+    enum v4l2_buf_type type;
+
+
+    requestBuffer.count = 1;
+    requestBuffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    requestBuffer.memory = V4L2_MEMORY_MMAP;
+
+    xioctl(cameraFileDescriptor, VIDIOC_REQBUFS, &requestBuffer);
+
+
+    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    buffer.memory = V4L2_MEMORY_MMAP;
+    buffer.index = 0;
+
+    xioctl(cameraFileDescriptor, VIDIOC_QUERYBUF, &buffer);
+
+    Frame_t frame;
+    frame.length = buffer.length;
+    frame.data = v4l2_mmap(
+        NULL,
+        buffer.length,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        cameraFileDescriptor,
+        buffer.m.offset
+    );
+
+    if (MAP_FAILED == frame.data) {
+        std::cerr << "FATAL ERROR: mmap() failure occured when trying to load a frame from the webcamera.\n";
+        exit(EXIT_FAILURE);
+    }
+
+
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    buffer.memory = V4L2_MEMORY_MMAP;
+    buffer.index = 0;
+    xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
+
+    bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    xioctl(cameraFileDescriptor, VIDIOC_STREAMON, &type);
+
+    fd_set fileDescriptors;
+    struct timeval timeout;
+
+    int response = 0;
+    do {
+        FD_ZERO(&fileDescriptors);
+        FD_SET(cameraFileDescriptor, &fileDescriptors);
+
+        /* Timeout. */
+        timeout.tv_sec = 0;
+        timeout.tv_usec = 500;
+
+        response = select(cameraFileDescriptor + 1, &fileDescriptors, NULL, NULL, &timeout);
+    } while ((response == -1 && (errno = EINTR)));
+
+    if (response == -1) {
+        std::cerr << "select\n";
+        //return nullptr;
+    }
+
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    buffer.memory = V4L2_MEMORY_MMAP;
+    xioctl(cameraFileDescriptor, VIDIOC_DQBUF, &buffer);
+
+    std::cout << buffer.bytesused << std::endl;
+
+    xioctl(cameraFileDescriptor, VIDIOC_QBUF, &buffer);
+
+
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    xioctl(cameraFileDescriptor, VIDIOC_STREAMOFF, &type);
 
     return frame;
 }
 
 Camera::~Camera() {
-
+    close(cameraFileDescriptor);
 }

--- a/tools/client/ClientMain.cpp
+++ b/tools/client/ClientMain.cpp
@@ -9,9 +9,9 @@
 #include <bitset>
 
 void writeFrame(std::string out_name, Frame_t frame) {
-    FILE* fout = fopen(out_name.c_str(), "w");
+    FILE* fout = fopen(out_name.c_str(), "a");
 
-    fwrite(frame.data, frame.length, 1, fout);
+    fwrite(frame.data, frame.dataLength, 1, fout);
     fclose(fout);
 }
 
@@ -19,7 +19,7 @@ int main() {
     std::cout << "starting\n";
 
     Camera cam(1);
-    int frameRate = 24;
+    int frameRate = 24 * 10;
 
     struct timeval t1, t2;
     double elapsedTime;
@@ -29,7 +29,7 @@ int main() {
 
     for(int i = 0; i < frameRate; i++) {
         Frame_t frame = cam.getFrame();
-        std::cout << frame.length << " done\n";
+        std::cout << "Frames " << i << " has length: " << frame.length << " done\n";
         writeFrame("1.raw", frame);
     }
 

--- a/tools/client/ClientMain.cpp
+++ b/tools/client/ClientMain.cpp
@@ -8,9 +8,61 @@
 
 #include <bitset>
 
-int main() {
+void writeFrame(std::string out_name, Frame_t frame) {
+    FILE* fout = fopen(out_name.c_str(), "w");
 
-    // Camera cam;
+    fwrite(frame.data, frame.length, 1, fout);
+    fclose(fout);
+}
+
+int main() {
+    std::cout << "starting\n";
+
+    Camera cam(1);
+    int frameRate = 24;
+
+    struct timeval t1, t2;
+    double elapsedTime;
+
+    // start timer
+    gettimeofday(&t1, NULL);
+
+    for(int i = 0; i < frameRate; i++) {
+        Frame_t frame = cam.getFrame();
+        std::cout << frame.length << " done\n";
+        writeFrame("1.raw", frame);
+    }
+
+    cam.stopStreaming();
+
+    // stop timer
+    gettimeofday(&t2, NULL);
+
+    elapsedTime = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
+    elapsedTime += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
+    std::cout << elapsedTime << " ms.\n";
+
+    /*
+    Frame_t frame = cam.getFrame(); writeFrame("0.ppm", frame);
+    std::cout << frame.length << "\n";
+    frame = cam.getFrame(); writeFrame("1.ppm", frame);
+    frame = cam.getFrame(); writeFrame("2.ppm", frame);
+    frame = cam.getFrame(); writeFrame("3.ppm", frame);
+    frame = cam.getFrame(); writeFrame("4.ppm", frame);
+    frame = cam.getFrame(); writeFrame("5.ppm", frame);
+    frame = cam.getFrame(); writeFrame("6.ppm", frame);
+    frame = cam.getFrame(); writeFrame("7.ppm", frame);
+    frame = cam.getFrame(); writeFrame("8.ppm", frame);
+    frame = cam.getFrame(); writeFrame("9.ppm", frame);
+    frame = cam.getFrame(); writeFrame("10.ppm", frame);
+    /*
+
+
+
+
+
+    std::cout << frame.length << std::endl;
+    /*
     RTPPacket packet(260, 0, 1024, "hello world");
     std::string msg = packet.getNetworkMessage();
 
@@ -25,6 +77,6 @@ int main() {
 
     udp.send("hello world");
     std::cout << "client received: '" + server.receive() + "'" << std::endl;
-
+*/
     return 0;
 }


### PR DESCRIPTION
The camera module now gets MPEG-4 AVC data instead of a RGB array, through the use of Video4Linux2 (V4L2).